### PR TITLE
Only download pihole if a newer version is wanted.

### DIFF
--- a/roles/pihole/tasks/main.yaml
+++ b/roles/pihole/tasks/main.yaml
@@ -58,7 +58,7 @@
     src: https://github.com/pi-hole/pi-hole/archive/refs/tags/v{{ pihole_version }}.zip
     dest: /tmp
     remote_src: true
-  when: (pihole_version_installed | length == 0) or pihole_version_installed is version_compare(pihile_version, '<')
+  when: (pihole_version_installed | length == 0) or pihole_version_installed is version_compare(pihole_version, '<')
 
 - name: Install PiHole
   ansible.builtin.shell: |
@@ -69,12 +69,12 @@
     rm -rf /tmp/*{{ pihole_version }}*
   register: process_status
   changed_when: false
-  when: (pihole_version_installed | length == 0) or pihole_version_installed is version_compare(pihile_version, '<')
+  when: (pihole_version_installed | length == 0) or pihole_version_installed is version_compare(pihole_version, '<')
 
 - name: Display installation process
   ansible.builtin.debug:
     var: process_status.stdout_lines
-  when: (pihole_version_installed | length == 0) or pihole_version_installed is version_compare(pihile_version, '<')
+  when: (pihole_version_installed | length == 0) or pihole_version_installed is version_compare(pihole_version, '<')
 
 - name: Check if Pi-hole FTL service is running
   ansible.builtin.systemd:

--- a/roles/pihole/tasks/main.yaml
+++ b/roles/pihole/tasks/main.yaml
@@ -7,6 +7,14 @@
     host_local_ipv6: "{{ ansible_default_ipv6.address }}"
   when: enable_ipv6_support
 
+- name: Determine the currently installed version of pihole
+  ansible.builtin.shell: grep -Po '^CORE_VERSION=(.+)' /etc/pihole/versions | cut -d '=' -f 2-
+  register: shell_output
+    
+- name: Set facts for PiHole version
+  ansible.builtin.set_fact:
+    pihole_version_installed: "{{ shell_output.stdout | replace('v', '') }}"
+
 - name: Ensures /etc/pihole dir exists
   ansible.builtin.file:
     path: /etc/pihole
@@ -50,6 +58,7 @@
     src: https://github.com/pi-hole/pi-hole/archive/refs/tags/v{{ pihole_version }}.zip
     dest: /tmp
     remote_src: true
+  when: (pihole_version_installed | length == 0) or pihole_version_installed is version_compare(pihile_version, '<')
 
 - name: Install PiHole
   ansible.builtin.shell: |
@@ -60,10 +69,12 @@
     rm -rf /tmp/*{{ pihole_version }}*
   register: process_status
   changed_when: false
+  when: (pihole_version_installed | length == 0) or pihole_version_installed is version_compare(pihile_version, '<')
 
 - name: Display installation process
   ansible.builtin.debug:
     var: process_status.stdout_lines
+  when: (pihole_version_installed | length == 0) or pihole_version_installed is version_compare(pihile_version, '<')
 
 - name: Check if Pi-hole FTL service is running
   ansible.builtin.systemd:


### PR DESCRIPTION
This change makes it so pihole is only re-downloaded and installed when the currently installed version is older than what's configured in the host vars. This should greatly improve the speed of updates so it doesn't keep downloading the same version of pihole when updating other configuration settings.

The only thing this might prevent is downgrading to an older version if someone would want to do that with this playbook, but I'm not sure how common of a need that is since I've never really had a pihole update break for me.

I'm not an expert in Ansible, so I'm sure there's probably a better way this could be handled.