### PR TITLE
feat: Expand pihole.toml configuration & bump nebula-sync v0.7.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 ## 📖 General Information
 This Ansible playbook will allow you to bootstrap a Highly Available Pi-hole cluster with:
 - [x] [keepalived](https://github.com/acassen/keepalived)
-- [x] [Nebula Sync](https://github.com/lovelaze/nebula-sync)
+- [x] [nebula-sync](https://github.com/lovelaze/nebula-sync)
 - [x] [unbound](https://github.com/NLnetLabs/unbound)
 - [x] [pihole-updatelists](https://github.com/jacklul/pihole-updatelists)
 

--- a/inventory/group_vars/all.yml
+++ b/inventory/group_vars/all.yml
@@ -49,6 +49,9 @@ pihole_bogus_priv: true # If "true", reverse lookups for private IPs return NXDO
 pihole_dns_cache_size: 10000 # # Sets the DNS cache size; higher values improve caching but increase memory usage. Default recommended: 10000.
 pihole_dnssec: false # Validate DNS replies using DNSSEC?
 pihole_show_dnssec: true # Enable DNSSEC logging and statistics.
+pihole_resolve_ipv4: true # Should FTL resolve IPv4 addresses to hostnames?
+pihole_resolve_ipv6: true # Should FTL resolve IPv6 addresses to hostnames?
+pihole_network_names: true # Should FTL attempt to derive client names from the network table?
 pihole_refresh_names: "IPV4_ONLY" # Controls PTR query refresh: "IPV4_ONLY" (IPv4 only, recommended), "ALL" (IPv4 & IPv6), "UNKNOWN" (resolve once), "NONE" (disable).
 pihole_rate_limit_count: 1000 # Maximum number of DNS queries allowed per client within the rate-limiting interval before being temporarily blocked.
 pihole_rate_limit_interval: 60 # Time interval (in seconds) for rate limiting; clients exceeding the query limit within this period will be temporarily blocked.
@@ -58,6 +61,17 @@ pihole_block_icloud_pr: true # If true, Pi-hole blocks Apple's iCloud Private Re
 pihole_ptr: "HOSTNAMEFQDN" # Defines the response for PTR queries to local interface addresses: "NONE", "HOSTNAME", "HOSTNAMEFQDN", or "PI.HOLE".
 pihole_max_db_days: 91 # Number of days to store DNS query history in the database (default: 91).
 pihole_db_interval: 60 # Time interval (in seconds) for writing queries to the database (default: 60).
+pihole_ntp_ipv4_active: false # Enable or disable IPv4 NTP server ("true" = listen on IPv4).
+pihole_ntp_ipv4_address: "" # IPv4 address to listen on for NTP requests ("" => 0.0.0.0).
+pihole_ntp_ipv6_active: false # Enable or disable IPv6 NTP server ("true" = listen on IPv6).
+pihole_ntp_ipv6_address: "" # IPv6 address to listen on for NTP requests ("" => ::).
+pihole_ntp_sync_active: true # Sync system time with an upstream NTP server ("true" = enabled).
+pihole_ntp_sync_server: "pool.ntp.org" # Upstream NTP server address (e.g. "pool.ntp.org").
+pihole_ntp_sync_interval: 3600 # Interval (seconds) between time sync attempts.
+pihole_ntp_sync_count: 8 # Number of requests to average before updating system clock.
+pihole_ntp_sync_rtc_set: false # Update hardware RTC if available.
+pihole_ntp_sync_rtc_device: "" # Path to RTC device ("" => auto-discovery).
+pihole_ntp_sync_rtc_utc: true # Whether RTC should be maintained in UTC.
 # pihole_rev_servers: [] # Optional list of CIDRs, targets, and domains for DNS conditional forwarding.
 # Example usage:
 # pihole_rev_servers:

--- a/inventory/group_vars/all.yml
+++ b/inventory/group_vars/all.yml
@@ -10,7 +10,7 @@ pihole_vip_ipv6: "fe80::53/64" # Floating (virtual) IPv6 for the failover betwee
 ## Nebula Sync Settings
 ## https://github.com/lovelaze/nebula-sync
 enable_nebula_sync: true
-nebula_sync_version: "v0.6.0" # https://github.com/lovelaze/nebula-sync/pkgs/container/nebula-sync
+nebula_sync_version: "v0.7.0" # https://github.com/lovelaze/nebula-sync/pkgs/container/nebula-sync
 nebula_sync_cron: "*/30 * * * *" # https://github.com/lovelaze/nebula-sync?tab=readme-ov-file#optional-environment-variables
 nebula_sync_client_skip_tls_verification: true # https://github.com/lovelaze/nebula-sync?tab=readme-ov-file#optional-environment-variables
 nebula_sync_run_gravity: true # https://github.com/lovelaze/nebula-sync?tab=readme-ov-file#optional-environment-variables

--- a/roles/pihole/tasks/main.yaml
+++ b/roles/pihole/tasks/main.yaml
@@ -118,14 +118,6 @@
     var: process_status.stdout_lines
   when: pihole_version != pihole_version_installed
 
-- name: Check if Pi-hole FTL service is running
-  ansible.builtin.systemd:
-    name: pihole-FTL
-  register: pihole_ftl_status
-  retries: 10
-  delay: 5
-  until: pihole_ftl_status.status.ActiveState == 'active'
-
 - name: Set Pi-hole FTL WEB password
   ansible.builtin.command: pihole setpassword {{ pihole_webpassword }}
   changed_when: false
@@ -134,3 +126,11 @@
   ansible.builtin.systemd:
     name: pihole-FTL
     state: restarted
+
+- name: Check if Pi-hole FTL service is running
+  ansible.builtin.systemd:
+    name: pihole-FTL
+  register: pihole_ftl_status
+  retries: 10
+  delay: 5
+  until: pihole_ftl_status.status.ActiveState == 'active'

--- a/roles/pihole/templates/pihole.toml.j2
+++ b/roles/pihole/templates/pihole.toml.j2
@@ -47,13 +47,21 @@
     mozillaCanary = {{ pihole_block_mozilla_canary | lower }}
     iCloudPrivateRelay = {{ pihole_block_icloud_pr | lower }}
 
-  [dns.reply.host]
-{% if enable_ipv6_support == true %}
-    IPv4 = "{{ pihole_vip_ipv4 }}"
-    IPv6 = "{{ pihole_vip_ipv6 }}"
-{% else %}
-    IPv4 = "{{ pihole_vip_ipv4 }}"
-{% endif %}
+    [dns.reply.host]
+      force4 = {{ (pihole_vip_ipv4 | length > 0) | lower }}
+      IPv4 = "{{ pihole_vip_ipv4 | regex_replace('/.*', '') if pihole_vip_ipv4 | length > 0 else '' }}"
+
+      force6 = {% if enable_ipv6_support and (pihole_vip_ipv6 | length > 0) %}true{% else %}false{% endif %}
+
+      IPv6 = "{{ pihole_vip_ipv6 | regex_replace('/.*', '') if enable_ipv6_support and pihole_vip_ipv6 | length > 0 else '' }}"
+
+    [dns.reply.blocking]
+      force4 = {{ (pihole_vip_ipv4 | length > 0) | lower }}
+      IPv4 = "{{ pihole_vip_ipv4 | regex_replace('/.*', '') if pihole_vip_ipv4 | length > 0 else '' }}"
+
+      force6 = {% if enable_ipv6_support and (pihole_vip_ipv6 | length > 0) %}true{% else %}false{% endif %}
+
+      IPv6 = "{{ pihole_vip_ipv6 | regex_replace('/.*', '') if enable_ipv6_support and pihole_vip_ipv6 | length > 0 else '' }}"
 
   [dns.rateLimit]
     count = {{ pihole_rate_limit_count }}
@@ -62,7 +70,29 @@
 [dhcp]
   active = false
 
+  [ntp.ipv4]
+    active = {{ pihole_ntp_ipv4_active | lower }}
+    address = "{{ pihole_ntp_ipv4_address }}"
+
+  [ntp.ipv6]
+    active = {{ pihole_ntp_ipv6_active | lower }}
+    address = "{{ pihole_ntp_ipv6_address }}"
+
+  [ntp.sync]
+    active = {{ pihole_ntp_sync_active | lower }}
+    server = "{{ pihole_ntp_sync_server }}"
+    interval = {{ pihole_ntp_sync_interval }}
+    count = {{ pihole_ntp_sync_count }}
+
+  [ntp.sync.rtc]
+    set = {{ pihole_ntp_sync_rtc_set | lower }}
+    device = "{{ pihole_ntp_sync_rtc_device }}"
+    utc = {{ pihole_ntp_sync_rtc_utc | lower }}
+
 [resolver]
+  resolveIPv4 = {{ pihole_resolve_ipv4 | lower }}
+  resolveIPv6 = {{ pihole_resolve_ipv6 | lower }}
+  networkNames = {{ pihole_network_names | lower }}
   refreshNames = "{{ pihole_refresh_names }}"
 
 [database]
@@ -78,7 +108,7 @@
     timeout = {{ pihole_web_session_timeout }}
 
   [webserver.interface]
-    boxed = {{ pihole_web_boxed_layout }}
+    boxed = {{ pihole_web_boxed_layout | lower }}
     theme = "{{ pihole_web_theme }}"
 
 [misc]

--- a/roles/pihole_updatelists/templates/pihole-updatelists.conf.j2
+++ b/roles/pihole_updatelists/templates/pihole-updatelists.conf.j2
@@ -16,4 +16,4 @@ REGEX_BLACKLIST_URL="{{ pihole_updatelists_regex_blacklist_url }}"
 {% if pihole_updatelists_regex_whitelist_url | length > 0 %}
 REGEX_WHITELIST_URL="{{ pihole_updatelists_regex_whitelist_url }}"
 {% endif %}
-UPDATE_GRAVITY=false
+UPDATE_GRAVITY=true


### PR DESCRIPTION
## Summary of Changes

###  Pi-hole Configuration (`pihole.toml`)
- Added support for `[ntp]` configuration:
  - `[ntp.ipv4]` and `[ntp.ipv6]`: Control NTP sync over IPv4/IPv6
  - `[ntp.sync]`: Configure NTP server, interval, and count
  - `[ntp.sync.rtc]`: Set RTC device and UTC usage
- Added `[resolver]` section:
  - `resolveIPv4`, `resolveIPv6`, and `networkNames` options for DNS resolution
- Enhanced `[dns.reply.host]` and `[dns.reply.blocking]`:
  - Automatically set IPv4/IPv6 reply IPs based on cluster VIP settings

### Nebula-Sync
- Bumped **Nebula-Sync** version from `v0.6.0` → `v0.7.0`

###  Other Changes
- Changed `UPDATE_GRAVITY=false` → `UPDATE_GRAVITY=true` in `pihole-updatelists` configuration

