### PR TITLE
Bump Pi-hole to 6.1, allow NTP in firewalld, and add pihole‑FTL restart retries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
-buffer/
+.ansible
+custom-pihole.toml
 .env/
 *.log
 .vscode

--- a/inventory/group_vars/all.yml
+++ b/inventory/group_vars/all.yml
@@ -24,7 +24,7 @@ enable_unbound: true
 unbound_verbosity: 0 # https://docs.pi-hole.net/guides/dns/unbound/#add-logging-to-unbound
 
 ## Pi-hole general configuration
-pihole_version: 6.0.5 # https://github.com/pi-hole/pi-hole/releases
+pihole_version: 6.1 # https://github.com/pi-hole/pi-hole/releases
 pihole_webpassword: "SUPER_SECURE_PASSWORD" # Web interface password set via `pihole -a -p`; stored as a hash in `pihole.toml`.
 pihole_local_domain: "homelab.local" # Options: "lan", "local", "home", or a custom domain (e.g., "homelab.local").
 pihole_web_domain: "{{ ansible_hostname }}.{{ pihole_local_domain }}" # Sets the Pi-hole web interface domain using the system hostname and local domain (e.g., "pihole-node1.lan"). 

--- a/roles/firewalld/tasks/main.yaml
+++ b/roles/firewalld/tasks/main.yaml
@@ -41,6 +41,13 @@
     state: enabled
   when: enable_ipv6_support
 
+- name: Allow NTP service
+  ansible.posix.firewalld:
+    service: ntp
+    permanent: true
+    immediate: true
+    state: enabled
+
 - name: Create ftl zone
   ansible.posix.firewalld:
     zone: ftl

--- a/roles/pihole/tasks/main.yaml
+++ b/roles/pihole/tasks/main.yaml
@@ -122,10 +122,18 @@
   ansible.builtin.command: pihole setpassword {{ pihole_webpassword }}
   changed_when: false
 
+- name: Wait 10 seconds before restarting pihole-FTL
+  ansible.builtin.pause:
+    seconds: 10
+
 - name: Restart pihole-FTL service
   ansible.builtin.systemd:
     name: pihole-FTL
     state: restarted
+  register: restart_result
+  until: restart_result is succeeded
+  retries: 3
+  delay: 5
 
 - name: Check if Pi-hole FTL service is running
   ansible.builtin.systemd:


### PR DESCRIPTION
## Summary of Changes

### Pi‑hole Version

* Bumped Pi‑hole to **6.1**

### Firewalld Role

* Added a rule to allow NTP traffic in the `firewalld` role

### Ansible Handler Improvements

* Added a 10‑second pause before restarting the `pihole‑FTL` service
* Configured retry logic (up to 3 attempts with a 5‑second delay) to ensure reliable restarts when the service doesn’t come up on the first try