### PR TITLE
feat: add Pi-hole dnsmasq passthrough settings

### DIFF
--- a/extensions/molecule/hetzner/scenarios/custom-config.yml
+++ b/extensions/molecule/hetzner/scenarios/custom-config.yml
@@ -51,6 +51,9 @@
     pihole_privacy_level: 2
     pihole_ntp_sync_server: "time.google.com"
     pihole_local_domain: "custom.test"
+    pihole_etc_dnsmasq_d: true
+    pihole_dnsmasq_lines:
+      - "add-subnet=32,128"
     # Keepalived tuning
     keepalived_check_interval: 2
     keepalived_check_timeout: 2

--- a/extensions/molecule/hetzner/verify/custom-config.yml
+++ b/extensions/molecule/hetzner/verify/custom-config.yml
@@ -143,6 +143,32 @@
         fail_msg: "Custom privacy level not applied (expected 2)"
         success_msg: "Custom privacy level correctly applied"
 
+    - name: Get misc.etc_dnsmasq_d
+      ansible.builtin.command:
+        cmd: pihole-FTL --config misc.etc_dnsmasq_d
+      register: _etc_dnsmasq_d
+      changed_when: false
+
+    - name: Verify dnsmasq.d loading is enabled
+      ansible.builtin.assert:
+        that:
+          - "'true' in (_etc_dnsmasq_d.stdout | lower)"
+        fail_msg: "misc.etc_dnsmasq_d not applied (expected true)"
+        success_msg: "misc.etc_dnsmasq_d correctly applied"
+
+    - name: Get misc.dnsmasq_lines
+      ansible.builtin.command:
+        cmd: pihole-FTL --config misc.dnsmasq_lines
+      register: _dnsmasq_lines
+      changed_when: false
+
+    - name: Verify custom dnsmasq lines
+      ansible.builtin.assert:
+        that:
+          - "'add-subnet=32,128' in _dnsmasq_lines.stdout"
+        fail_msg: "misc.dnsmasq_lines not applied (expected add-subnet=32,128)"
+        success_msg: "misc.dnsmasq_lines correctly applied"
+
     - name: Get local domain
       ansible.builtin.command:
         cmd: pihole-FTL --config dns.domain.name
@@ -228,6 +254,7 @@
           - "Pi-hole upstream -> local Unbound: PASS"
           - "Custom cache size (5000): PASS"
           - "Custom privacy level (2): PASS"
+          - "Custom dnsmasq settings: PASS"
           - "Custom local domain: PASS"
           - "DNS via peer ({{ _peer_ip }}): PASS"
           - "DNS via local Unbound: PASS"

--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -115,6 +115,12 @@ pihole_domain_needed: false
 pihole_bogus_priv: true
 pihole_dnssec: false
 pihole_show_dnssec: true
+pihole_etc_dnsmasq_d: false             # Load additional dnsmasq snippets from /etc/dnsmasq.d
+pihole_dnsmasq_lines: []                # Extra dnsmasq lines injected into Pi-hole FTL
+# Example: send full ECS upstream metadata
+# pihole_etc_dnsmasq_d: true
+# pihole_dnsmasq_lines:
+#   - "add-subnet=32,128"
 pihole_ptr: "HOSTNAMEFQDN"              # NONE, HOSTNAME, HOSTNAMEFQDN, PI.HOLE
 
 # DNS Cache & Database

--- a/roles/pihole/README.md
+++ b/roles/pihole/README.md
@@ -45,6 +45,8 @@ Installs and configures Pi-hole DNS sinkhole.
 | `pihole_dns_cache_size` | `10000` | DNS cache size |
 | `pihole_dnssec` | `false` | Enable DNSSEC validation |
 | `pihole_show_dnssec` | `true` | Show DNSSEC status in web UI |
+| `pihole_etc_dnsmasq_d` | `false` | Load additional dnsmasq configuration files from `/etc/dnsmasq.d` |
+| `pihole_dnsmasq_lines` | `[]` | Additional dnsmasq lines injected into Pi-hole FTL |
 
 **Client resolution:**
 
@@ -134,6 +136,20 @@ None
 ## Security Note
 
 Always use `ansible-vault` for `pihole_web_password`. The password is set securely using stdin and `no_log: true`.
+
+## Advanced DNSMasq Settings
+
+Pi-hole exposes advanced dnsmasq passthrough options through `pihole_etc_dnsmasq_d` and `pihole_dnsmasq_lines`.
+
+Example: send full ECS upstream metadata for testing split-horizon behavior:
+
+```yaml
+pihole_etc_dnsmasq_d: true
+pihole_dnsmasq_lines:
+  - "add-subnet=32,128"
+```
+
+Use these settings carefully. Invalid dnsmasq options can prevent DNS resolution from starting.
 
 ## License
 

--- a/roles/pihole/defaults/main.yml
+++ b/roles/pihole/defaults/main.yml
@@ -58,6 +58,8 @@ pihole_bogus_priv: true
 pihole_dns_cache_size: 10000
 pihole_dnssec: false
 pihole_show_dnssec: true
+pihole_etc_dnsmasq_d: false
+pihole_dnsmasq_lines: []
 
 # Client resolution
 pihole_resolve_ipv4: true

--- a/roles/pihole/meta/main.yml
+++ b/roles/pihole/meta/main.yml
@@ -196,6 +196,17 @@ argument_specs:
         required: false
         default: true
         description: Show DNSSEC status in web interface
+      pihole_etc_dnsmasq_d:
+        type: bool
+        required: false
+        default: false
+        description: Load additional dnsmasq configuration files from /etc/dnsmasq.d
+      pihole_dnsmasq_lines:
+        type: list
+        elements: str
+        required: false
+        default: []
+        description: Additional dnsmasq configuration lines to inject into Pi-hole FTL
 
       # Client resolution
       pihole_resolve_ipv4:

--- a/roles/pihole/templates/pihole.toml.j2
+++ b/roles/pihole/templates/pihole.toml.j2
@@ -142,4 +142,6 @@
 # MISC CONFIGURATION
 # =============================================================================
 [misc]
+  etc_dnsmasq_d = {{ pihole_etc_dnsmasq_d | lower }}
+  dnsmasq_lines = {{ pihole_dnsmasq_lines | to_json }}
   privacylevel = {{ pihole_privacy_level }}


### PR DESCRIPTION
Add support for advanced dnsmasq passthrough settings in the Pi-hole role.

- add pihole_etc_dnsmasq_d and pihole_dnsmasq_lines variables
- render misc.etc_dnsmasq_d and misc.dnsmasq_lines in pihole.toml
- document the new settings and ECS add-subnet example
- extend the custom-config Molecule scenario to verify dnsmasq passthrough is applied